### PR TITLE
Fix undefined group id in group edit navigate

### DIFF
--- a/client/src/components/dashboards/alarmDashboard.js
+++ b/client/src/components/dashboards/alarmDashboard.js
@@ -97,7 +97,7 @@ function AlarmDashboard() {
                       className="fs-4 text-start" 
                       variant="light"
                       id={`group-${group.id}`}
-                      onClick={handleEditGroup}
+                      onClick={() => handleEditGroup(group)}
                       > {group.aGroupName} </Button>
                       <div className="d-flex justify-content-end">
                         <CDBSwitch


### PR DESCRIPTION
This fixes the issue of undefined in the navigation request. The group dashboard component can now grab this id from the navigation parameter and use it to display the correct group for editing purposes.